### PR TITLE
hack: remove the PR file changed checks for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - '**.md'
-      - 'demo/**'
-      - 'docs/**'
   release:
     types: [ published ]
   workflow_dispatch:


### PR DESCRIPTION
Yes, a bit hacky and not the proper solution, but gets this bug silenced.
I don't like that CI always fails on docs PRs.

A proper solution would be to skip all except `CI FInished` if just docs were changed.