### PR TITLE
chore: add annotations to our github docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,7 @@ jobs:
           file: .github/files/multi-platform.Dockerfile
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
+          annotations: ${{ steps.docker_meta.outputs.annotations }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
 


### PR DESCRIPTION
We seem to be not passing along the annotations.
I think this is the reason why https://ghcr.io/maplibre/martin does not show a description.#

docs on this:
https://github.com/docker/metadata-action?tab=readme-ov-file#annotations