### PR TITLE
docs: Update architecture.md to remove metrics details

### DIFF
--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -654,10 +654,6 @@ Martin doesn't include built-in auth, but supports:
 Martin exposes Prometheus metrics via `/metrics`:
 
 - HTTP request counters and histograms
-- Tile generation time histograms
-- Cache hit/miss rates
-- Database connection pool stats
-- Error rates by type
 
 {{#endtab }}
 {{#tab name="Health Checks" }}

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -655,6 +655,8 @@ Martin exposes Prometheus metrics via `/metrics`:
 
 - HTTP request counters and histograms
 
+If you need more in-depth observability, we would be very open to having your PR to add more metrics, this is currently very barebones.
+
 {{#endtab }}
 {{#tab name="Health Checks" }}
 


### PR DESCRIPTION
Removed specific Prometheus metrics from documentation.